### PR TITLE
chore: exclude test files from Codecov coverage

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -14,3 +14,6 @@ github_checks:
   # Don't mark lines that aren't covered
   annotations: false
 
+ignore:
+  - "tests/**/*"
+


### PR DESCRIPTION
Exclude test files from coverage reports to avoid misleading warnings.

Closes #612